### PR TITLE
Add Google Secret Manager and Runtime Configurator backends

### DIFF
--- a/configstore/__init__.py
+++ b/configstore/__init__.py
@@ -1,7 +1,8 @@
 """Retrieve settings and secrets from different storages."""
 
 from .backends import (
-    AwsSsmBackend, DictBackend, DockerSecretBackend, DotenvBackend, EnvVarBackend,
+    AwsSsmBackend, DictBackend, DockerSecretBackend, DotenvBackend,
+    EnvVarBackend, GoogleSecretManagerBackend, GoogleRuntimeConfiguratorBackend
 )
 from .store import Store, SettingNotFoundException
 
@@ -13,6 +14,8 @@ __all__ = [
     'DotenvBackend',
     'DockerSecretBackend',
     'AwsSsmBackend',
+    'GoogleSecretManagerBackend',
+    'GoogleRuntimeConfiguratorBackend'
 ]
 
 __version__ = '0.9.dev'

--- a/configstore/backends/__init__.py
+++ b/configstore/backends/__init__.py
@@ -3,6 +3,8 @@ from .dict import DictBackend
 from .docker_secret import DockerSecretBackend
 from .dotenv import DotenvBackend
 from .env_var import EnvVarBackend
+from .google_runtime_configurator import GoogleRuntimeConfiguratorBackend
+from .google_secret_manager import GoogleSecretManagerBackend
 
 __all__ = [
     'EnvVarBackend',
@@ -10,4 +12,6 @@ __all__ = [
     'DotenvBackend',
     'DockerSecretBackend',
     'AwsSsmBackend',
+    "GoogleRuntimeConfiguratorBackend",
+    "GoogleSecretManagerBackend"
 ]

--- a/configstore/backends/google_runtime_configurator.py
+++ b/configstore/backends/google_runtime_configurator.py
@@ -1,0 +1,22 @@
+try:
+    from google.cloud import runtimeconfig
+except ImportError:  # pragma: no cover
+    runtimeconfig = None
+
+
+class GoogleRuntimeConfiguratorBackend:
+    """Backend for Google Runtime Configurator.
+    """
+
+    def __init__(self, project_id, config_name):
+        client = runtimeconfig.Client(project=project_id)
+        self.config = client.config(config_name)
+
+    def get_setting(self, key):
+        """Returns the named item from runtime configurator"""
+        variable = self.config.get_variable(key)
+
+        if variable is None:
+            return None
+        else:
+            return variable.text

--- a/configstore/backends/google_secret_manager.py
+++ b/configstore/backends/google_secret_manager.py
@@ -1,0 +1,28 @@
+try:
+    from google.cloud import secretmanager
+    from google.api_core.exceptions import NotFound
+except ImportError:  # pragma: no cover
+    secretmanager = None
+    NotFound = None
+
+
+class GoogleSecretManagerBackend:
+    """Backend for Google Secrets Manager (GSM).
+    """
+
+    def __init__(self, project_id):
+        self.project_id = project_id
+        self.client = secretmanager.SecretManagerServiceClient()
+
+    def get_setting(self, key):
+        """Returns the named secret from GSM"""
+        full_name = f"projects/{self.project_id}/secrets/{key}/versions/latest"
+
+        # Access the secret version
+        try:
+            response = self.client.access_secret_version(name=full_name)
+        except NotFound:
+            return None
+
+        # Return the decoded payload
+        return response.payload.data.decode("UTF-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ requires = [
 # Note that django-dotenv does not actually use or need Django
 dotenv = ["django-dotenv"]
 awsssm = ["boto3"]
+google_runtime_configurator = ["google-cloud-runtimeconfig"]
+google_secret_manager = ["google-cloud-secret-manager"]
 
 [tool.flit.metadata.urls]
 Documentation = "https://github.com/caravancoop/configstore/blob/main/example.py"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39
+envlist = py310
 # enable pyproject.toml support
 minversion = 3.4.0
 isolated_build = True


### PR DESCRIPTION
This PR adds in support for [Google Secret Manager](https://cloud.google.com/secret-manager) and [Google Runtime Configurator](https://cloud.google.com/deployment-manager/runtime-configurator) backends.