### PR TITLE
Add caching to configstore google backends

### DIFF
--- a/configstore/backends/google_runtime_configurator.py
+++ b/configstore/backends/google_runtime_configurator.py
@@ -8,15 +8,41 @@ class GoogleRuntimeConfiguratorBackend:
     """Backend for Google Runtime Configurator.
     """
 
-    def __init__(self, project_id, config_name):
+    def __init__(self, project_id: str, config_name: str, cache_keys: bool):
         client = runtimeconfig.Client(project=project_id)
         self.config = client.config(config_name)
 
-    def get_setting(self, key):
-        """Returns the named item from runtime configurator"""
+        # If cache_keys is true, we load a list of all keys at init time. This
+        # will make things a lot quicker when trying to load a key that doesn't exist
+        if cache_keys:
+            self.cached_keys = self._list()
+        else:
+            self.cached_keys = None
+
+    def _list(self) -> set[str]:
+        """Lists all the keys of items stored in an environment"""
+        variables = self.config.list_variables()
+        return {variable.name for variable in list(variables)}
+
+    def _get(self, key) -> str:
+        """Low level method to get setting from runtime configurator"""
         variable = self.config.get_variable(key)
 
         if variable is None:
             return None
         else:
             return variable.text
+
+    def get_setting(self, key) -> str:
+        """Returns the named item from runtime configurator,
+        optionally checking a cached list of keys that exist before doing
+        so"""
+
+        # If we have cached a list of keys, check that list before
+        # trying to load a variable. This will speed things up a lot
+        # in the case where the key doesn't exist
+        if self.cached_keys is not None:
+            if key not in self.cached_keys:
+                return None
+
+        return self._get(key)

--- a/configstore/backends/google_secret_manager.py
+++ b/configstore/backends/google_secret_manager.py
@@ -10,12 +10,24 @@ class GoogleSecretManagerBackend:
     """Backend for Google Secrets Manager (GSM).
     """
 
-    def __init__(self, project_id):
+    def __init__(self, project_id: str, cache_keys: str):
         self.project_id = project_id
         self.client = secretmanager.SecretManagerServiceClient()
 
-    def get_setting(self, key):
-        """Returns the named secret from GSM"""
+        # If cache_keys is true, we load a list of all keys at init time. This
+        # will make things a lot quicker when trying to load a key that doesn't exist
+        if cache_keys:
+            self.cached_keys = self._list()
+        else:
+            self.cached_keys = None
+
+    def _list(self) -> set[str]:
+        """Lists all the names of secrets stored in an environment"""
+        parent = f"projects/{self.project_id}"
+        results = self.client.list_secrets(parent=parent)
+        return {response.name.split("/")[-1] for response in results}
+
+    def _get(self, key: str) -> str:
         full_name = f"projects/{self.project_id}/secrets/{key}/versions/latest"
 
         # Access the secret version
@@ -26,3 +38,16 @@ class GoogleSecretManagerBackend:
 
         # Return the decoded payload
         return response.payload.data.decode("UTF-8")
+
+    def get_setting(self, key: str) -> str:
+        """Returns the named item from GSM,
+        optionally checking a cached list of keys that exist before doing
+        so"""
+        # If we have cached a list of keys, check that list before
+        # trying to load a variable. This will speed things up a lot
+        # in the case where the key doesn't exist
+        if self.cached_keys is not None:
+            if key not in self.cached_keys:
+                return None
+
+        return self._get(key)

--- a/example.py
+++ b/example.py
@@ -3,6 +3,8 @@ import configstore
 # Create a store object with a stack of backends to look for settings
 # in environment first, then docker secrets, then a .env file
 store = configstore.Store([
+    configstore.GoogleSecretManagerBackend("my-test-project", True),
+    configstore.GoogleRuntimeConfiguratorBackend("my-test-project", "general", True),
     configstore.EnvVarBackend(),
     configstore.DockerSecretBackend(),
 ])


### PR DESCRIPTION
When trying to read a Google Runtime Config or Secrets Manager that doesn't exist, it takes apx 0.3s. This PR optionally caches a list of settings that exist (this is a quick operation) and so calling `get_setting` for entries that don't exist will be a lot faster.